### PR TITLE
Homepage copy tweaks: Software attribution and publications metrics date

### DIFF
--- a/index.html
+++ b/index.html
@@ -434,7 +434,7 @@
 	================================================== -->
 	<div class="page-header" id="publications">
 		<h1>Selected Publications</h1>
-		<p class="lead">Highlights from a corpus of more than 800 papers cited over 168,000 times (H-index 158, i10-index 774). See Prof. Sham's <a href="https://scholar.google.com.hk/citations?user=rHTAld0AAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a> profile for a complete list.</p>
+		<p class="lead">Highlights from a corpus of more than 800 papers cited over 168,000 times (H-index 158, i10-index 774; as of April 2026). See Prof. Sham's <a href="https://scholar.google.com.hk/citations?user=rHTAld0AAAAJ&amp;hl=en" target="_blank" rel="noopener">Google Scholar</a> profile for a complete list.</p>
 	</div>
 
 	<h3 class="pub-section-heading">Recent work (2022 &ndash; present)</h3>

--- a/index.html
+++ b/index.html
@@ -353,7 +353,7 @@
 	================================================== -->
 	<div class="page-header" id="software">
 		<h1>Software &amp; Tools</h1>
-		<p class="lead">Open-source methods developed in the lab.</p>
+		<p class="lead">Open-source methods developed in the lab or supervised by Prof. Pak Sham.</p>
 	</div>
 
 	<div class="row">


### PR DESCRIPTION
## Summary

Two small copy tweaks on the homepage:

- **Software section subtitle**: changed `Open-source methods developed in the lab.` → `Open-source methods developed in the lab or supervised by Prof. Pak Sham.` This better reflects authorship of tools like PLINK, which was developed by Shaun Purcell during his PhD with Prof. Sham.
- **Selected Publications subtitle**: added `as of April 2026` to the citation/H-index numbers so the metrics are honest about being a Google Scholar snapshot that will drift over time.

## Files changed

- `index.html` (2 single-line edits)

## Test plan

- [ ] `https://shamlab.github.io/#software` — subtitle reads "...developed in the lab or supervised by Prof. Pak Sham."
- [ ] `https://shamlab.github.io/#publications` — subtitle includes "(H-index 158, i10-index 774; as of April 2026)"

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeaPFdA4bhwJhqwqtKZLDc)_