### PR TITLE
Remove MOST Torch Programme recognition from News and bio

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,13 +326,6 @@
 		<div class="col-md-4">
 			<div class="news-card">
 				<span class="news-date">2025</span>
-				<h3 class="news-title">National-level talent recognition</h3>
-				<p>Prof. Pak Sham has been selected as a national-level talent under the Ministry of Science and Technology Torch Programme (a designation comparable to the Changjiang Scholar honour).</p>
-			</div>
-		</div>
-		<div class="col-md-4">
-			<div class="news-card">
-				<span class="news-date">2025</span>
 				<h3 class="news-title">Associate Editor of <em>GENETICS</em></h3>
 				<p>Prof. Sham has joined <em>GENETICS</em>, the flagship journal of the Genetics Society of America, as an Associate Editor &mdash; further to his tenure as Editor-in-Chief of <em>Human Heredity</em> (2017&ndash;2023).</p>
 			</div>

--- a/people.html
+++ b/people.html
@@ -174,7 +174,6 @@
 				</dl>
 				<dl class="dl-horizontal">
 					<dt>Honours &amp; awards</dt>
-					<dd>National-level talent, MOST Torch Programme (2025) &mdash; equivalent in rank to the Changjiang Scholar Programme</dd>
 					<dd>China Leader in Medicine, research.com (2022, 2023, 2024)</dd>
 					<dd>Grammer Research Award, European Spine Society (2022)</dd>
 					<dd>Robert Elston Award for Outstanding Paper, International Genetic Epidemiology Society (2017)</dd>


### PR DESCRIPTION
## Summary

Per request, removed the "2025 National-level talent recognition (MOST Torch Programme)" mention from two places:

- **`index.html` News section**: dropped the corresponding card. Two cards remain (GENETICS Associate Editor 2025; research.com Top 20 Chinese scientist in medicine 2022–2024).
- **`people.html` Pak Sham bio modal**: dropped the matching line from the "Honours & awards" list.

## Files changed

- `index.html` — 1 card removed (8 lines)
- `people.html` — 1 `<dd>` removed

## Note on layout

The News section now shows 2 cards on a 3-column grid, leaving the right third empty. If you'd prefer them to fill the row evenly, the `col-md-4` classes on the two remaining cards can be changed to `col-md-6` — let me know if you want that.

## Test plan

- [ ] `https://shamlab.github.io/#news` — only 2 news cards visible (GENETICS / research.com)
- [ ] `https://shamlab.github.io/people.html` — open Pak Sham modal → Honours & awards list no longer mentions MOST Torch / Changjiang Scholar

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeaPFdA4bhwJhqwqtKZLDc)_