### PR TITLE
Add Zijing Yang to Graduate Students

### DIFF
--- a/people.html
+++ b/people.html
@@ -557,6 +557,15 @@
 		</div>
 	</div>
 
+	<div class="row">
+		<div class="col-lg-4">
+		<img class="img-circle" src="./graphics/profiles/placeholder.jpg" alt="Zijing Yang" width="140" height="140">
+		<h2>Zijing Yang</h2>
+		<p>Reading between the SNPs.</p>
+		<p><a class="btn btn-default" type="button" data-toggle="modal" data-target="#zjyang">View details &raquo;</a></p>
+		</div>
+	</div>
+
 	<!-- Student modals -->
 
 	<div id="plam" class="modal fade" role="dialog">
@@ -643,6 +652,37 @@
 					<dt>Research interests</dt>
 					<dd>Multi-omics data integration</dd>
 					<dd>Rare-variant analysis in complex disorders</dd>
+				</dl>
+			</div>
+			<div class="modal-footer">
+			<button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+			</div>
+		</div>
+		</div>
+	</div>
+
+	<div id="zjyang" class="modal fade" role="dialog">
+		<div class="modal-dialog modal-lg">
+		<div class="modal-content">
+			<div class="modal-header">
+			<button type="button" class="close" data-dismiss="modal">&times;</button>
+			<h3 class="modal-title">Zijing Yang 楊子婧</h3>
+			</div>
+			<div class="modal-body">
+				<div class="row">
+				<div class="col-lg-4">
+					<img class="img-rounded" src="./graphics/profiles/placeholder.jpg" alt="Zijing Yang" width="170" height="170">
+				</div>
+				<div class="col-lg-8">
+					<h5>Ph.D. Student in Statistical Genetics</h5>
+					<p><span class="label label-primary" style="font-weight:normal; font-size: 90%">GWAS</span> <span class="label label-info" style="font-weight:normal; font-size: 90%">Fine-mapping</span> <span class="label label-danger" style="font-weight:normal; font-size: 90%">Stats</span></p>
+				</div>
+				</div>
+				<hr>
+				<dl class="dl-horizontal">
+					<dt>Research interests</dt>
+					<dd>Statistical fine-mapping of complex-trait associations</dd>
+					<dd>Heritability partitioning across functional annotations</dd>
 				</dl>
 			</div>
 			<div class="modal-footer">


### PR DESCRIPTION
## Summary

Adds **Zijing Yang 楊子婧** as a new PhD student in the Graduate Students section.

Follows the same placeholder convention as the other recent additions (Perry Lam, Detao Zhang, Zeluan Li):
- Blank placeholder photo
- Email left blank
- Generic statistical-genetics research interests (statistical fine-mapping, heritability partitioning)
- Standard `View details` modal

## Files changed

- `people.html` — new card in Graduate Students grid + new `#zjyang` modal

## Test plan

- [ ] `https://shamlab.github.io/people.html#students` — Zijing Yang card appears below the existing row of three PhD students
- [ ] Clicking "View details" opens the modal with name, role, and research interests

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeaPFdA4bhwJhqwqtKZLDc)_